### PR TITLE
Bypass for EU Google Consent Page

### DIFF
--- a/metafinder/utils/finder/google.py
+++ b/metafinder/utils/finder/google.py
@@ -16,7 +16,10 @@ def search(target, total):
 		iterations += 1
 	## Check https://github.com/n4xh4ck5/RastLeak - thanks Nacho
 	url_base = f"https://www.google.com/search?q=(ext:pdf OR ext:doc OR ext:docx OR ext:xls OR ext:xlsx OR ext:ppt OR ext:pptx)+(site:*.{target} OR site:{target})&num={num}"
-	cookies = {"CONSENT": "YES+srp.gws"}
+	cookies = {
+		"CONSENT": "PENDING+999",
+		"SOCS": "CAESXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX_",
+	}
 	while (start < iterations) and (len(documents) < total):
 		try:
 			url = url_base + f"&start={start}"


### PR DESCRIPTION
### :pushpin: References

- **Issue:** [[BUG](https://github.com/Josue87/MetaFinder/issues)](https://github.com/Josue87/MetaFinder/issues/24)

### :tophat: What is the goal?

Changing the `CONSENT` cookie in order to bypass Google Consent

### :art: A picture is worth a thousand words

![image](https://github.com/user-attachments/assets/2d814fef-d23b-427f-b495-422a1356b716)

### :white_check_mark: Checklist

- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked this works with manual QA
